### PR TITLE
Add Security and Intro papers from 9p.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ PR's welcome for all edits or new projects.
 
 ### Papers
 
-* []() -
+* [Plan 9 From Bell Labs](https://9p.io/sys/doc/9.pdf) - Overview of the Plan9 system itself
+* [Security in Plan 9](https://9p.io/sys/doc/auth.pdf) - Overview of the security architecture of Plan9
+
 
 ### Manuals
 


### PR DESCRIPTION
Not sure if it would be preferable to link directly to https://9p.io/sys/doc/ instead, which lists a plethora of "papers" including these ones.