### PR TITLE
Added additional talk: 'Plan 9 - Not Dead, Just Resting' by Ori Bernstein

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ PR's welcome for all edits or new projects.
 
 ### First Edition
 
-* []() -
+* [Plan 9 from Bell Labs Programmer's Manual (1st Edition)](http://doc.cat-v.org/plan_9/1st_edition/manual.pdf)
 
 ### Talks
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ PR's welcome for all edits or new projects.
 ### Talks
 
 * [The Name Game](https://youtu.be/3d1SHOCCDn0) - Talk on Plan9 and Inferno by Charles Forsyth
+* [Plan 9: Not Dead, Just Resting](https://youtu.be/6m3GuoaxRNM) - Talk on Plan9 and 9front by Ori Bernstein
 
 ## Applications
 


### PR DESCRIPTION
Added a YouTube link for a talk about Plan9 and 9front given by Ori Bernstein for NYC*BUG in Oct 2019.