### PR TITLE
Fix broken links in the language section + formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,11 @@ PR's welcome for all edits or new projects.
 
 * [fe](https://git.sr.ht/~ft/fe) - A tiny, embeddable Lisp-like language
 * [Go](https://golang.org/) - The Go programming language
-* [Idris 2](https://git.sr.ht/~ft/idris2) - A dependently typed programming language
+* [Idris 2](https://www.idris-lang.org/pages/download.html) - A dependently typed programming language
 * [Lua](http://download.redis.io/releases/redis-3.0.1.tar.gz) - Lua from Redis
-* [Myrddin](https://bitbucket.org/oridb/mc) - Systems language by Ori Bernstein
+* [Myrddin](https://myrlang.org/) - Systems language by Ori Bernstein
 * [Ocaml](http://caml.inria.fr/pub/distrib/ocaml-4.07/ocaml-4.07.1.tar.gz) - Ocaml
-* [Scheme 9](http://t3x.org/s9fes/s9fes-20180823.tgz) - Scheme 9 from Empty Space
+* [Scheme 9](https://t3x.org/s9fes/) - Scheme 9 from Empty Space
 * [Squeak](https://github.com/henesy/squeak) - Squeak/Smalltalk from de0u/squeak
 * [Tcl](https://9p.io/sources/contrib/fgb/root/sys/src/cmd/tcl/) - Tcl port by fgb
 * [TinyScheme](https://download.sourceforge.net/tinyscheme/tinyscheme-1.41.tar.gz) - TinyScheme

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ PR's welcome for all edits or new projects.
 
 *Languages which are known to be buildable/operational on Plan9.*
 
-* [fe](https://git.sr.ht/~ft/fe) - A tiny, embeddable Lisp-like language
+* [aa](https://git.sr.ht/~ft/aa) - A tiny, embeddable Lisp-like language
 * [Go](https://golang.org/) - The Go programming language
 * [Idris 2](https://www.idris-lang.org/pages/download.html) - A dependently typed programming language
 * [Lua](http://download.redis.io/releases/redis-3.0.1.tar.gz) - Lua from Redis

--- a/README.md
+++ b/README.md
@@ -29,9 +29,6 @@ PR's welcome for all edits or new projects.
 * [Modding Rio](https://wiki.xxiivv.com/site/rio.html) - Tutorials on how to add a wallpaper and change colors.
 * [Plan9 GUI Examples](https://wiki.xxiivv.com/site/plan9_c.html) - Tutorials to learn about GUI development on Plan9.
 * [Plan9 Desktop Guide](https://pspodcasting.net/dan/blog/2019/plan9_desktop.html) - a all in one guide to get started with Plan9.
-### Blogs
-
-* []() -
 
 ### Sites
 


### PR DESCRIPTION
There are a few broken links in the language section, I researched and found ones I think will adequately replace them. I also removed the blog section as there was nothing in there, however if you want to keep that I can add that back in.